### PR TITLE
Update GithubUpdater.php

### DIFF
--- a/includes/updater/GithubUpdater.php
+++ b/includes/updater/GithubUpdater.php
@@ -209,7 +209,8 @@ class GithubUpdater {
 	 */
 	private function get_tmpfile_data( $string ) {
 
-		$temp = tmpfile();
+		$temp_file = wp_tempnam();
+		$temp = fopen($temp_file, 'r+');
 		$tmpfilename = stream_get_meta_data($temp)['uri'];
 		fwrite( $temp, $string);
 


### PR DESCRIPTION
Temp fix to fix error that may occur if the PHP installation on the server doesn't have access to the system's temporary directory or the necessary permissions to create files in it.